### PR TITLE
Add Markov chain anomaly detection demo

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,11 @@
-Hello Git
+Markov AIS anomaly detection demo
+
+This repository contains a small dataset (data/houston_data_small.csv) and a
+simple example of training a Markov chain for anomaly detection.
+
+Run the demo:
+
+    python scripts/demo_markov.py
+
+The script trains on speeds from the dataset, builds a transition matrix, and
+reports improbable transitions as potential anomalies.

--- a/scripts/demo_markov.py
+++ b/scripts/demo_markov.py
@@ -1,0 +1,70 @@
+"""Train a simple Markov chain on AIS speed data and report anomalies."""
+
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+from typing import List
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from markov_model import MarkovChain
+
+# Discretization of speed over ground (SOG) into qualitative states
+BINS = [0.0, 1.0, 5.0, 15.0, float("inf")]
+LABELS = ["stopped", "slow", "medium", "fast"]
+
+
+def discretize_sog(sog: float) -> str:
+    for i in range(len(BINS) - 1):
+        if BINS[i] <= sog < BINS[i + 1]:
+            return LABELS[i]
+        
+    return LABELS[-1]
+
+
+def load_states(path: str, limit: int | None = None) -> List[str]:
+    """Read ``limit`` rows from ``path`` and return discretized states."""
+    states: List[str] = []
+    with open(path, newline="") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) <= 5:
+                continue
+            try:
+                sog = float(row[5])
+            except ValueError:
+                continue
+            states.append(discretize_sog(sog))
+            if limit is not None and len(states) >= limit:
+                break
+    return states
+
+
+def main() -> None:
+    # Load up to 60k states to keep runtime reasonable
+    states = load_states("data/houston_data_small.csv", limit=60000)
+    train, test = states[:50000], states[50000:]
+
+    model = MarkovChain(LABELS)
+    model.fit(train)
+
+    scores = model.anomaly_scores(test)
+    threshold = 5.0  # equivalent to probability < exp(-5) ≈ 0.0067
+    anomalies = [(i, s) for i, s in enumerate(scores) if s > threshold]
+
+    print(f"Loaded {len(states)} states: {len(train)} train, {len(test)} test")
+    print(f"Found {len(anomalies)} anomalies with score > {threshold}")
+
+    for i, score in anomalies[:5]:
+        a, b = test[i], test[i + 1]
+        prob = model.transition_prob(a, b)
+        print(f"{i}: {a}->{b}, prob={prob:.5f}, score={score:.2f}")
+
+    avg = sum(scores) / len(scores) if scores else 0.0
+    print(f"Average score: {avg:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/markov_model.py
+++ b/src/markov_model.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Simple discrete-time Markov chain with Laplace smoothing.
+
+This module implements a first-order Markov chain that can be trained on a
+sequence of discrete states.  After fitting, transition probabilities and
+anomaly scores can be computed for new sequences.
+"""
+
+from collections import defaultdict
+import math
+from typing import Iterable, List
+
+
+class MarkovChain:
+    """First-order Markov chain for discrete states.
+
+    Parameters
+    ----------
+    states:
+        Iterable of all possible state labels.  The order is preserved and used
+        to build the transition matrix.
+    """
+
+    def __init__(self, states: Iterable[str]):
+        self.states: List[str] = list(states)
+        # Count transitions from state i to j
+        self._counts = {s: defaultdict(int) for s in self.states}
+        # Probabilities P(j|i); start with Laplace smoothing (1 everywhere)
+        self._probs = {s: {t: 1.0 for t in self.states} for s in self.states}
+
+    def fit(self, sequence: Iterable[str]) -> None:
+        """Estimate transition probabilities from a sequence of states."""
+        seq = list(sequence)
+        for a, b in zip(seq[:-1], seq[1:]):
+            if a in self._counts and b in self._counts:
+                self._counts[a][b] += 1
+        # Convert counts to probabilities with Laplace smoothing
+        for a in self.states:
+            total = sum(self._counts[a][b] + 1 for b in self.states)
+            self._probs[a] = {
+                b: (self._counts[a][b] + 1) / total for b in self.states
+            }
+
+    def transition_prob(self, a: str, b: str) -> float:
+        """Return probability of transitioning from ``a`` to ``b``."""
+        return self._probs[a][b]
+
+    def sequence_loglik(self, sequence: Iterable[str]) -> float:
+        """Log-likelihood of a sequence under the model."""
+        seq = list(sequence)
+        loglik = 0.0
+        for a, b in zip(seq[:-1], seq[1:]):
+            loglik += math.log(self.transition_prob(a, b))
+        return loglik
+
+    def anomaly_scores(self, sequence: Iterable[str]) -> List[float]:
+        """Negative log-probability for each transition in ``sequence``."""
+        seq = list(sequence)
+        scores = []
+        for a, b in zip(seq[:-1], seq[1:]):
+            scores.append(-math.log(self.transition_prob(a, b)))
+        return scores


### PR DESCRIPTION
## Summary
- implement reusable `MarkovChain` with Laplace smoothing
- add AIS speed anomaly demo using the chain
- document how to run the demo

## Testing
- `python scripts/demo_markov.py > /tmp/demo.log && tail -n 20 /tmp/demo.log`


------
https://chatgpt.com/codex/tasks/task_b_68b6eac51e3483308be436a081dab08e